### PR TITLE
removes deprecated description and cause for std::error::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,19 @@ where
     }
 }
 
+impl<E: 'static> StdError for Error<E>
+where
+    E: StdError,
+{
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        if let Self::Operation { error, .. } = self {
+            Some(error)
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,26 +208,11 @@ where
     E: StdError,
 {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), FmtError> {
-        write!(formatter, "{}", self.description())
-    }
-}
-
-impl<E> StdError for Error<E>
-where
-    E: StdError,
-{
-    fn description(&self) -> &str {
-        match *self {
-            Error::Operation { ref error, .. } => error.description(),
-            Error::Internal(ref description) => description,
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
-        match *self {
-            Error::Operation { ref error, .. } => Some(error),
-            Error::Internal(_) => None,
-        }
+        let msg = match *self {
+            Error::Operation { ref error, .. } => format!("{}", error),
+            Error::Internal(ref error) => format!("{}", error),
+        };
+        write!(formatter, "{}", msg)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,8 @@ where
 {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), FmtError> {
         let msg = match *self {
-            Error::Operation { ref error, .. } => format!("{}", error),
-            Error::Internal(ref error) => format!("{}", error),
+            Error::Operation { ref error, .. } => error.to_string(),
+            Error::Internal(ref error) => error.to_string(),
         };
         write!(formatter, "{}", msg)
     }


### PR DESCRIPTION
closes https://github.com/habitat-sh/habitat/issues/7202

![](https://i.giphy.com/media/BTbo1iT1yEfOE/source.gif)


Signed-off-by: Jeremy J. Miller <jm@chef.io>